### PR TITLE
Removed portal html page

### DIFF
--- a/frontend/apps/interface/captive-portal-path.html
+++ b/frontend/apps/interface/captive-portal-path.html
@@ -1,1 +1,0 @@
-captive portal


### PR DESCRIPTION
Removed temporary `/interface/captive-portal-path.html ` as captive portal is integrated into Vue.js frontend [fixes #23]