### PR TITLE
Integrate ePub reader into File Manager

### DIFF
--- a/frontend/apps/file-manager/extensions/pathconfig.php
+++ b/frontend/apps/file-manager/extensions/pathconfig.php
@@ -41,7 +41,6 @@ class PathConfig extends IFM_Extensions {
                     'IFM_API_DELETE'        => '1',
                     'IFM_API_EXTRACT'       => '1',
                     'IFM_API_UPLOAD'        => '1',
-                    // 'IFM_API_REMOTEUPLOAD'  => '1',
                     'IFM_API_RENAME'        => '1'
                 )
             ),
@@ -58,7 +57,6 @@ class PathConfig extends IFM_Extensions {
                     'IFM_API_DELETE'        => '1',
                     'IFM_API_EXTRACT'       => '1',
                     'IFM_API_UPLOAD'        => '1',
-                    // 'IFM_API_REMOTEUPLOAD'  => '1',
                     'IFM_API_RENAME'        => '1'
                 )
             ),

--- a/frontend/apps/file-manager/extensions/pathconfig.php
+++ b/frontend/apps/file-manager/extensions/pathconfig.php
@@ -25,7 +25,7 @@ class PathConfig extends IFM_Extensions {
                 'config'    => array(
                     'IFM_ROOT_DIR'          => '/app/public/storage/fileshare/',
                     'IFM_ROOT_PUBLIC_URL'   => '/storage/fileshare/',
-                    'IFM_EPUB_READER'   => '1'
+                    'IFM_EPUB_READER'       => '1'
                 )
             ),
             '/upload-files/'    => array(

--- a/frontend/apps/file-manager/extensions/pathconfig.php
+++ b/frontend/apps/file-manager/extensions/pathconfig.php
@@ -41,7 +41,7 @@ class PathConfig extends IFM_Extensions {
                     'IFM_API_DELETE'        => '1',
                     'IFM_API_EXTRACT'       => '1',
                     'IFM_API_UPLOAD'        => '1',
-                    'IFM_API_REMOTEUPLOAD'  => '1',
+                    // 'IFM_API_REMOTEUPLOAD'  => '1',
                     'IFM_API_RENAME'        => '1'
                 )
             ),
@@ -58,7 +58,7 @@ class PathConfig extends IFM_Extensions {
                     'IFM_API_DELETE'        => '1',
                     'IFM_API_EXTRACT'       => '1',
                     'IFM_API_UPLOAD'        => '1',
-                    'IFM_API_REMOTEUPLOAD'  => '1',
+                    // 'IFM_API_REMOTEUPLOAD'  => '1',
                     'IFM_API_RENAME'        => '1'
                 )
             ),

--- a/frontend/apps/file-manager/extensions/pathconfig.php
+++ b/frontend/apps/file-manager/extensions/pathconfig.php
@@ -24,7 +24,8 @@ class PathConfig extends IFM_Extensions {
                 ),
                 'config'    => array(
                     'IFM_ROOT_DIR'          => '/app/public/storage/fileshare/',
-                    'IFM_ROOT_PUBLIC_URL'   => '/storage/fileshare/'
+                    'IFM_ROOT_PUBLIC_URL'   => '/storage/fileshare/',
+                    'IFM_EPUB_READER'   => '1'
                 )
             ),
             '/upload-files/'    => array(
@@ -68,7 +69,8 @@ class PathConfig extends IFM_Extensions {
                 ),
                 'config'    => array(
                     'IFM_ROOT_DIR'          => '/app/public/storage/library',
-                    'IFM_ROOT_PUBLIC_URL'   => '/storage/library/'
+                    'IFM_ROOT_PUBLIC_URL'   => '/storage/library/',
+                    'IFM_EPUB_READER'   => '1'
                 )
             )
         );

--- a/frontend/apps/file-manager/src/ifm.js
+++ b/frontend/apps/file-manager/src/ifm.js
@@ -168,42 +168,40 @@ function IFM(params) {
 			}
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 	
-			const isEpubFile = self.config.epub_reader && item.extension === "epub";
+			if (self.config.epub_reader && item.extension === "epub") {
+				var linkBasePath = self.pathCombine(window.location.origin, self.config.epub_reader_url);
 
-			if (self.config.isDocroot && !self.config.forceproxy) {
-				if (isEpubFile) {
-					var linkBasePath = self.pathCombine(window.location.origin, self.config.epub_reader_url);
+				if (self.config.isDocroot && !self.config.forceproxy) {
 					var epubFilePath = self.pathCombine(self.currentDir, item.name);
-					var epubFileUrl = self.hrefEncode(self.pathCombine(self.api.substring(0, self.api.lastIndexOf('/')), epubFilePath));
-					item.link = linkBasePath.concat(epubFileUrl);
-				} else {
-					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
-				}
-			} else if (self.config.download && self.config.zipnload) {
-				if (self.config.root_public_url) {
-					if (self.config.root_public_url.charAt(0) == "/") {
-						if (isEpubFile) {
-							var linkBasePath = self.pathCombine(window.location.origin, self.config.epub_reader_url);
+					var epubFileUrl = self.pathCombine(self.api.substring(0, self.api.lastIndexOf('/')), epubFilePath);
+					item.link = self.hrefEncode(linkBasePath.concat(epubFileUrl));
+				} else if (self.config.download && self.config.zipnload) {
+					if (self.config.root_public_url) {
+						if (self.config.root_public_url.charAt(0) == "/") {
 							var epubFileUrl = self.hrefEncode(self.pathCombine(window.location.origin, self.config.root_public_url, self.currentDir, item.name));
 							item.link = linkBasePath.concat(epubFileUrl)
 						} else {
-							item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-						}
-					} else {
-						if (isEpubFile) {
-							var linkBasePath = self.pathCombine(window.location.origin, self.config.epub_reader_url);
 							var epubFileUrl = self.hrefEncode(self.pathCombine(self.config.root_public_url, self.currentDir, item.name));
 							item.link = linkBasePath.concat(epubFileUrl)
-						} else {
-							item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 						}
 					}
-				} else {
-					item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 				}
-			} else {
-				item.link = '#';
 			} 
+
+			if (!item.link) {
+				if( self.config.isDocroot && !self.config.forceproxy )
+					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
+				else if (self.config.download && self.config.zipnload) {
+					if (self.config.root_public_url) {
+						if (self.config.root_public_url.charAt(0) == "/")
+							item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						else
+							item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+					} else
+						item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
+				} else
+					item.link = '#';
+			}
 
 			if( ! self.inArray( item.name, [".", ".."] ) ) {
 				item.dragdrop = 'draggable="true"';

--- a/frontend/apps/file-manager/src/ifm.js
+++ b/frontend/apps/file-manager/src/ifm.js
@@ -167,13 +167,22 @@ function IFM(params) {
 			}
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 			if( self.config.isDocroot && !self.config.forceproxy )
-				item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
+				if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+					item.link = "http://"+window.location.host+self.config.epub_reader_url+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+self.hrefEncode( self.pathCombine( self.currentDir, item.name ) );
+				} else
+					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
 			else if (self.config.download && self.config.zipnload) {
 				if (self.config.root_public_url) {
 					if (self.config.root_public_url.charAt(0) == "/")
-						item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+							item.link = "http://"+window.location.host+self.config.epub_reader_url+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						} else
+							item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 					else
-						item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+							item.link = "http://"+window.location.host+self.config.epub_reader_url+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						} else
+							item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 				} else
 					item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 			} else

--- a/frontend/apps/file-manager/src/main.php
+++ b/frontend/apps/file-manager/src/main.php
@@ -61,7 +61,9 @@ class IFM {
 		"disable_mime_detection" => 0,
 		"showrefresh" => 0,
 		"forceproxy" => 0,
-		"confirmoverwrite" => 1
+		"confirmoverwrite" => 1,
+ 		"epub_reader" => 0,
+ 		"epub_reader_url" => '/epub_reader/?url='
 	);
 
 	private $config = array();
@@ -112,6 +114,7 @@ class IFM {
 		$this->config['showrefresh'] =  getenv('IFM_GUI_REFRESH') !== false ? intval( getenv('IFM_GUI_REFRESH') ) : $this->config['showrefresh'] ;
 		$this->config['forceproxy'] =  getenv('IFM_GUI_FORCEPROXY') !== false ? intval( getenv('IFM_GUI_FORCEPROXY') ) : $this->config['forceproxy'] ;
 		$this->config['confirmoverwrite'] =  getenv('IFM_GUI_CONFIRMOVERWRITE') !== false ? intval( getenv('IFM_GUI_CONFIRMOVERWRITE') ) : $this->config['confirmoverwrite'] ;
+		$this->config['epub_reader'] =  getenv('IFM_EPUB_READER') !== false ? intval( getenv('IFM_EPUB_READER') ) : $this->config['epub_reader'] ;
 
 		// optional settings
 		if( getenv('IFM_SESSION_LIFETIME') !== false )

--- a/frontend/apps/interface/src/layouts/MainLayout.vue
+++ b/frontend/apps/interface/src/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <q-header elevated>
-      <q-toolbar v-if="!(currentPath.path == '/captive_portal' || currentPath.path == '/epub_reader')">
+      <q-toolbar v-if="!(currentPath.path == '/captive_portal' || currentPath.path == '/epub_reader/')">
         <div class="ml-1">
           <router-link to="/">
             <img

--- a/frontend/apps/interface/src/layouts/MainLayout.vue
+++ b/frontend/apps/interface/src/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <q-header elevated>
-      <q-toolbar v-if="!(currentPath.path == '/captive_portal' || currentPath.path == '/epub_reader/')">
+      <q-toolbar v-if="!(currentPath.path == '/captive_portal' || currentPath.path == '/captive_portal/' || currentPath.path == '/epub_reader/')">
         <div class="ml-1">
           <router-link to="/">
             <img


### PR DESCRIPTION
When clicking a .epub file in file manager (as non-admin) instead of downloading the file, it will redirect to an epub reader stored at `/epub_reader`. That `epub_reader` receives the URL to open from `?url=http://url-to-the-filemanager-file`. 

Remote upload has been disabled as it was a little temperamental, and not really a necessary feature for now. 